### PR TITLE
Fix silent data loss when log message exceeds stackalloc buffer

### DIFF
--- a/src/Logsmith.Generator/Emission/MethodEmitter.cs
+++ b/src/Logsmith.Generator/Emission/MethodEmitter.cs
@@ -206,6 +206,8 @@ internal static class MethodEmitter
             sb.AppendLine($"        global::Logsmith.LogManager.Dispatch(in __entry, __utf8Message, __state, WriteProperties_{method.MethodName});");
         }
 
+        // Return any ArrayPool buffer rented during overflow
+        sb.AppendLine("        writer.Dispose();");
         sb.AppendLine("    }");
         return sb.ToString();
     }

--- a/src/Logsmith/Utf8LogWriter.cs
+++ b/src/Logsmith/Utf8LogWriter.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Unicode;
 
@@ -6,19 +7,31 @@ namespace Logsmith;
 
 public ref struct Utf8LogWriter
 {
-    private readonly Span<byte> _buffer;
+    private Span<byte> _buffer;
     private int _position;
+    private byte[]? _rented;
 
     public Utf8LogWriter(Span<byte> buffer)
     {
         _buffer = buffer;
         _position = 0;
+        _rented = null;
+    }
+
+    public void Dispose()
+    {
+        var rented = _rented;
+        if (rented is not null)
+        {
+            _rented = null;
+            ArrayPool<byte>.Shared.Return(rented);
+        }
     }
 
     public void Write(ReadOnlySpan<byte> utf8Literal)
     {
         if (utf8Literal.Length > _buffer.Length - _position)
-            return;
+            Grow(utf8Literal.Length);
 
         utf8Literal.CopyTo(_buffer[_position..]);
         _position += utf8Literal.Length;
@@ -26,18 +39,18 @@ public ref struct Utf8LogWriter
 
     public void WriteFormatted<T>(in T value) where T : IUtf8SpanFormattable
     {
-        if (value.TryFormat(_buffer[_position..], out int bytesWritten, default, null))
-        {
-            _position += bytesWritten;
-        }
+        int bytesWritten;
+        while (!value.TryFormat(_buffer[_position..], out bytesWritten, default, null))
+            Grow(_buffer.Length);
+        _position += bytesWritten;
     }
 
     public void WriteFormatted<T>(in T value, ReadOnlySpan<char> format) where T : IUtf8SpanFormattable
     {
-        if (value.TryFormat(_buffer[_position..], out int bytesWritten, format, null))
-        {
-            _position += bytesWritten;
-        }
+        int bytesWritten;
+        while (!value.TryFormat(_buffer[_position..], out bytesWritten, format, null))
+            Grow(_buffer.Length);
+        _position += bytesWritten;
     }
 
     public void WriteString(string? value)
@@ -52,10 +65,35 @@ public ref struct Utf8LogWriter
         if (status == OperationStatus.Done)
         {
             _position += bytesWritten;
+            return;
+        }
+
+        // Buffer too small — grow to exact requirement and retry
+        Grow(Encoding.UTF8.GetByteCount(value));
+        status = Utf8.FromUtf16(value, _buffer[_position..], out _, out bytesWritten);
+        if (status == OperationStatus.Done)
+        {
+            _position += bytesWritten;
         }
     }
 
     public ReadOnlySpan<byte> GetWritten() => _buffer[.._position];
 
     public int BytesWritten => _position;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void Grow(int needed)
+    {
+        int required = _position + needed;
+        int newSize = Math.Max(_buffer.Length * 2, required);
+        var newArray = ArrayPool<byte>.Shared.Rent(newSize);
+        _buffer[.._position].CopyTo(newArray);
+
+        var old = _rented;
+        _rented = newArray;
+        _buffer = newArray;
+
+        if (old is not null)
+            ArrayPool<byte>.Shared.Return(old);
+    }
 }

--- a/tests/Logsmith.Tests/Utf8LogWriterTests.cs
+++ b/tests/Logsmith.Tests/Utf8LogWriterTests.cs
@@ -15,6 +15,7 @@ public class Utf8LogWriterTests
 
         var result = Encoding.UTF8.GetString(writer.GetWritten());
         Assert.That(result, Is.EqualTo("3.14"));
+        writer.Dispose();
     }
 
     [Test]
@@ -27,5 +28,97 @@ public class Utf8LogWriterTests
 
         var result = Encoding.UTF8.GetString(writer.GetWritten());
         Assert.That(result, Is.EqualTo("42"));
+        writer.Dispose();
+    }
+
+    [Test]
+    public void WriteString_WithCurlyBraces_PreservesBraces()
+    {
+        Span<byte> buffer = stackalloc byte[512];
+        var writer = new Utf8LogWriter(buffer);
+
+        writer.Write("Vulkan validation: "u8);
+        writer.WriteString("{VkBuffer 0x00000001234ABCDEF} - Memory type not suitable");
+
+        var result = Encoding.UTF8.GetString(writer.GetWritten());
+        Assert.That(result, Is.EqualTo("Vulkan validation: {VkBuffer 0x00000001234ABCDEF} - Memory type not suitable"));
+        writer.Dispose();
+    }
+
+    [Test]
+    public void WriteString_OverflowBuffer_FallsBackToArrayPool()
+    {
+        // Buffer only fits the literal prefix, not the string param
+        Span<byte> buffer = stackalloc byte[30];
+        var writer = new Utf8LogWriter(buffer);
+
+        writer.Write("Prefix: "u8); // 8 bytes, leaves 22 bytes
+        writer.WriteString("{VkBuffer 0x00000001234ABCDEF} - Memory type not suitable"); // 57 bytes — overflows
+
+        var result = Encoding.UTF8.GetString(writer.GetWritten());
+        Assert.That(result, Is.EqualTo("Prefix: {VkBuffer 0x00000001234ABCDEF} - Memory type not suitable"));
+        writer.Dispose();
+    }
+
+    [Test]
+    public void WriteString_LongMessage_PreservedViaArrayPoolFallback()
+    {
+        // Max generated buffer is 4096 bytes. A single string param can easily exceed that —
+        // stack traces, serialized payloads, validation messages, SQL queries, etc.
+        const int maxGeneratedBuffer = 4096;
+        Span<byte> buffer = stackalloc byte[maxGeneratedBuffer];
+        var writer = new Utf8LogWriter(buffer);
+
+        writer.Write("Payload: "u8); // 9 bytes
+
+        // 8KB string — double the max buffer. Not unusual for serialized objects,
+        // full stack traces, or verbose diagnostic output.
+        var longMessage = new string('X', 8192);
+
+        writer.WriteString(longMessage);
+
+        var result = Encoding.UTF8.GetString(writer.GetWritten());
+        Assert.That(result, Is.EqualTo("Payload: " + longMessage));
+        Assert.That(writer.BytesWritten, Is.EqualTo(9 + 8192));
+        writer.Dispose();
+    }
+
+    [Test]
+    public void Write_LiteralOverflow_PreservedViaArrayPoolFallback()
+    {
+        Span<byte> buffer = stackalloc byte[4];
+        var writer = new Utf8LogWriter(buffer);
+
+        writer.Write("Hello, world!"u8); // 13 bytes into 4-byte buffer
+
+        var result = Encoding.UTF8.GetString(writer.GetWritten());
+        Assert.That(result, Is.EqualTo("Hello, world!"));
+        writer.Dispose();
+    }
+
+    [Test]
+    public void WriteFormatted_Overflow_PreservedViaArrayPoolFallback()
+    {
+        Span<byte> buffer = stackalloc byte[4];
+        var writer = new Utf8LogWriter(buffer);
+
+        writer.WriteFormatted(123456789L); // needs ~9 bytes, only 4 available
+
+        var result = Encoding.UTF8.GetString(writer.GetWritten());
+        Assert.That(result, Is.EqualTo("123456789"));
+        writer.Dispose();
+    }
+
+    [Test]
+    public void Dispose_NoOverflow_NoOp()
+    {
+        Span<byte> buffer = stackalloc byte[128];
+        var writer = new Utf8LogWriter(buffer);
+
+        writer.Write("hello"u8);
+
+        // Dispose on stackalloc-only path should be a no-op (no rented buffer to return)
+        writer.Dispose();
+        Assert.Pass();
     }
 }


### PR DESCRIPTION
## Summary

`Utf8LogWriter` previously dropped writes silently when the fixed stackalloc buffer was too small. This caused entire string parameters (e.g. long Vulkan validation messages, stack traces, serialized payloads) to vanish from log output with no indication. The writer now falls back to `ArrayPool<byte>` on overflow, with `Dispose()` returning the rented buffer after dispatch.

## Reason for the change

Users reported that runtime string values containing text like `{VkBuffer 0x...}` appeared to be "eaten" — when in reality the entire string parameter was being silently dropped because it exceeded the 128-byte budget allocated for string params in the stackalloc buffer. This affects any log method where the message content exceeds the estimated buffer size (clamped at 4096 bytes max), which is common for:

- Vulkan/graphics validation layer messages
- Full stack traces
- Serialized objects / JSON payloads
- SQL queries
- Verbose diagnostic output

## Impacts of changes

- **`Utf8LogWriter`**: All write methods (`Write`, `WriteString`, `WriteFormatted`) now grow via `ArrayPool<byte>.Shared` when the stackalloc buffer is exhausted, instead of silently discarding content.
- **`Grow()`**: Marked `[MethodImpl(MethodImplOptions.NoInlining)]` to keep the hot path (no overflow) lean and inlineable.
- **Generated code**: Now emits `writer.Dispose()` after dispatch to return any rented buffer.
- **8 new/updated unit tests** covering overflow scenarios for literals, strings, and formatted values.

## Migration Steps

None. This is a transparent behavioral fix. No API surface changes, no configuration required.

## Performance Considerations

- **Hot path (no overflow)**: Zero overhead. The stackalloc buffer is used as before. `Dispose()` is a null check on `_rented`.
- **Cold path (overflow)**: One `ArrayPool<byte>.Shared.Rent` + copy of existing bytes + `Return` on dispose. This is the standard .NET pooling pattern and avoids GC pressure.
- `WriteString` computes the exact byte count needed via `Encoding.UTF8.GetByteCount()` so it grows precisely once.
- `WriteFormatted` retries in a doubling loop since the exact formatted size isn't known upfront.

## Security Considerations

None. No new input surfaces, no external data handling changes.

## Breaking changes

### Public consumer-facing changes

None. `Utf8LogWriter` is a `ref struct` used internally by generated code. The public API surface is unchanged.

### Internal non-consumer changes

- `Utf8LogWriter._buffer` changed from `readonly Span<byte>` to `Span<byte>` (required for `Grow` to reassign it).
- `Utf8LogWriter` gains a `byte[]? _rented` field and `Dispose()` method.
- Generated method bodies now include a `writer.Dispose()` call after dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)