### PR TITLE
Add LogManager shutdown, sink ownership, and drain timeout

### DIFF
--- a/src/Logsmith/Internal/LogConfig.cs
+++ b/src/Logsmith/Internal/LogConfig.cs
@@ -32,4 +32,10 @@ internal sealed class LogConfig
             try { monitor.Dispose(); } catch { }
         }
     }
+
+    internal async ValueTask DisposeAllAsync()
+    {
+        DisposeMonitors();
+        await Sinks.DisposeSinksAsync();
+    }
 }

--- a/src/Logsmith/Internal/SinkSet.cs
+++ b/src/Logsmith/Internal/SinkSet.cs
@@ -4,11 +4,13 @@ internal sealed class SinkSet
 {
     internal readonly ILogSink[] TextSinks;
     internal readonly IStructuredLogSink[] StructuredSinks;
+    internal readonly ILogSink[] AllSinks;
 
-    internal SinkSet(ILogSink[] textSinks, IStructuredLogSink[] structuredSinks)
+    internal SinkSet(ILogSink[] textSinks, IStructuredLogSink[] structuredSinks, ILogSink[] allSinks)
     {
         TextSinks = textSinks;
         StructuredSinks = structuredSinks;
+        AllSinks = allSinks;
     }
 
     internal static SinkSet Classify(List<ILogSink> sinks)
@@ -25,6 +27,24 @@ internal sealed class SinkSet
             }
         }
 
-        return new SinkSet(textSinks, structuredList.ToArray());
+        return new SinkSet(textSinks, structuredList.ToArray(), sinks.ToArray());
+    }
+
+    internal async ValueTask DisposeSinksAsync()
+    {
+        foreach (var sink in AllSinks)
+        {
+            try
+            {
+                if (sink is IAsyncDisposable asyncDisposable)
+                    await asyncDisposable.DisposeAsync();
+                else
+                    sink.Dispose();
+            }
+            catch
+            {
+                // Swallow — same pattern as DisposeMonitors()
+            }
+        }
     }
 }

--- a/src/Logsmith/LogConfigBuilder.cs
+++ b/src/Logsmith/LogConfigBuilder.cs
@@ -45,10 +45,12 @@ public sealed class LogConfigBuilder
 
     public void AddFileSink(string path, ILogFormatter? formatter = null, bool shared = false,
                             Sinks.RollingInterval rollingInterval = Sinks.RollingInterval.None,
-                            long maxFileSizeBytes = 10 * 1024 * 1024)
+                            long maxFileSizeBytes = 10 * 1024 * 1024,
+                            TimeSpan? drainTimeout = null)
     {
         AddSink(new Sinks.FileSink(path, formatter: formatter, shared: shared,
-            rollingInterval: rollingInterval, maxFileSizeBytes: maxFileSizeBytes));
+            rollingInterval: rollingInterval, maxFileSizeBytes: maxFileSizeBytes,
+            drainTimeout: drainTimeout));
     }
 
     public void AddDebugSink(ILogFormatter? formatter = null)
@@ -56,9 +58,11 @@ public sealed class LogConfigBuilder
         AddSink(new Sinks.DebugSink(formatter: formatter));
     }
 
-    public void AddStreamSink(Stream stream, bool leaveOpen = false, ILogFormatter? formatter = null)
+    public void AddStreamSink(Stream stream, bool leaveOpen = false, ILogFormatter? formatter = null,
+                              TimeSpan? drainTimeout = null)
     {
-        AddSink(new Sinks.StreamSink(stream, formatter: formatter, leaveOpen: leaveOpen));
+        AddSink(new Sinks.StreamSink(stream, formatter: formatter, leaveOpen: leaveOpen,
+            drainTimeout: drainTimeout));
     }
 
     public void ClearSinks()

--- a/src/Logsmith/LogManager.cs
+++ b/src/Logsmith/LogManager.cs
@@ -8,6 +8,10 @@ public static class LogManager
     private static int _initialized;
     private static Action<Exception>? _exceptionHandler;
     private static int _exceptionsCaptured;
+    private static int _processExitRegistered;
+    private static int _shutdownCompleted;
+
+    private static readonly TimeSpan ProcessExitTimeout = TimeSpan.FromSeconds(5);
 
     public static void Initialize(Action<LogConfigBuilder> configure)
     {
@@ -17,6 +21,9 @@ public static class LogManager
         var builder = new LogConfigBuilder();
         configure(builder);
         _config = builder.Build();
+
+        Interlocked.Exchange(ref _shutdownCompleted, 0);
+        RegisterProcessExitHook();
     }
 
     public static void Reconfigure(Action<LogConfigBuilder> configure)
@@ -25,7 +32,56 @@ public static class LogManager
         var builder = new LogConfigBuilder();
         configure(builder);
         _config = builder.Build();
-        old?.DisposeMonitors();
+
+        if (old is not null)
+            Task.Run(async () => await old.DisposeAllAsync());
+    }
+
+    public static async ValueTask ReconfigureAsync(Action<LogConfigBuilder> configure)
+    {
+        var old = _config;
+        var builder = new LogConfigBuilder();
+        configure(builder);
+        _config = builder.Build();
+
+        if (old is not null)
+            await old.DisposeAllAsync();
+    }
+
+    public static async ValueTask ShutdownAsync(TimeSpan? timeout = null)
+    {
+        if (Interlocked.CompareExchange(ref _shutdownCompleted, 1, 0) != 0)
+            return;
+
+        StopCapturingUnhandledExceptions();
+
+        var old = Interlocked.Exchange(ref _config, null);
+        Interlocked.Exchange(ref _initialized, 0);
+
+        if (old is null)
+            return;
+
+        if (timeout is null)
+        {
+            await old.DisposeAllAsync();
+        }
+        else
+        {
+            using var cts = new CancellationTokenSource(timeout.Value);
+            try
+            {
+                await old.DisposeAllAsync().AsTask().WaitAsync(cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                // Disposal timed out — best effort, move on
+            }
+        }
+    }
+
+    public static void Shutdown(TimeSpan? timeout = null)
+    {
+        ShutdownAsync(timeout).AsTask().GetAwaiter().GetResult();
     }
 
     public static bool IsEnabled(LogLevel level)
@@ -171,6 +227,19 @@ public static class LogManager
         e.SetObserved();
     }
 
+    private static void RegisterProcessExitHook()
+    {
+        if (Interlocked.CompareExchange(ref _processExitRegistered, 1, 0) != 0)
+            return;
+
+        AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
+    }
+
+    private static void OnProcessExit(object? sender, EventArgs e)
+    {
+        Shutdown(ProcessExitTimeout);
+    }
+
     internal static void SetMinimumLevel(LogLevel level)
     {
         var current = _config;
@@ -196,6 +265,9 @@ public static class LogManager
         var old = _config;
         _config = null;
         Interlocked.Exchange(ref _initialized, 0);
-        old?.DisposeMonitors();
+        Interlocked.Exchange(ref _shutdownCompleted, 0);
+
+        if (old is not null)
+            old.DisposeAllAsync().AsTask().GetAwaiter().GetResult();
     }
 }

--- a/src/Logsmith/Sinks/BufferedLogSink.cs
+++ b/src/Logsmith/Sinks/BufferedLogSink.cs
@@ -15,10 +15,13 @@ public abstract class BufferedLogSink : ILogSink, IAsyncDisposable
     private readonly Channel<BufferedEntry> _channel;
     private readonly Task _drainTask;
     private readonly CancellationTokenSource _cts = new();
+    private readonly TimeSpan _drainTimeout;
 
-    protected BufferedLogSink(LogLevel minimumLevel = LogLevel.Trace, int capacity = 1024)
+    protected BufferedLogSink(LogLevel minimumLevel = LogLevel.Trace, int capacity = 1024,
+                              TimeSpan? drainTimeout = null)
     {
         MinimumLevel = minimumLevel;
+        _drainTimeout = drainTimeout ?? TimeSpan.FromSeconds(30);
         _channel = Channel.CreateBounded<BufferedEntry>(new BoundedChannelOptions(capacity)
         {
             FullMode = BoundedChannelFullMode.Wait,
@@ -71,7 +74,25 @@ public abstract class BufferedLogSink : ILogSink, IAsyncDisposable
     public async ValueTask DisposeAsync()
     {
         _channel.Writer.Complete();
-        await _drainTask;
+
+        if (_drainTimeout == Timeout.InfiniteTimeSpan)
+        {
+            await _drainTask;
+        }
+        else
+        {
+            using var timeoutCts = new CancellationTokenSource(_drainTimeout);
+            try
+            {
+                await _drainTask.WaitAsync(timeoutCts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                // Drain timed out — cancel the drain loop so it stops processing
+                await _cts.CancelAsync();
+            }
+        }
+
         _cts.Dispose();
         await OnDisposeAsync();
     }

--- a/src/Logsmith/Sinks/FileSink.cs
+++ b/src/Logsmith/Sinks/FileSink.cs
@@ -20,8 +20,9 @@ public class FileSink : BufferedLogSink
     public FileSink(string path, LogLevel minimumLevel = LogLevel.Trace,
                     long maxFileSizeBytes = 10 * 1024 * 1024,
                     ILogFormatter? formatter = null, bool shared = false,
-                    RollingInterval rollingInterval = RollingInterval.None)
-        : base(minimumLevel)
+                    RollingInterval rollingInterval = RollingInterval.None,
+                    TimeSpan? drainTimeout = null)
+        : base(minimumLevel, drainTimeout: drainTimeout)
     {
         _basePath = Path.GetFullPath(path);
         _maxFileSizeBytes = maxFileSizeBytes;

--- a/src/Logsmith/Sinks/StreamSink.cs
+++ b/src/Logsmith/Sinks/StreamSink.cs
@@ -11,8 +11,9 @@ public class StreamSink : BufferedLogSink
     private readonly bool _leaveOpen;
 
     public StreamSink(Stream stream, LogLevel minimumLevel = LogLevel.Trace,
-                      ILogFormatter? formatter = null, bool leaveOpen = false, int capacity = 1024)
-        : base(minimumLevel, capacity)
+                      ILogFormatter? formatter = null, bool leaveOpen = false, int capacity = 1024,
+                      TimeSpan? drainTimeout = null)
+        : base(minimumLevel, capacity, drainTimeout: drainTimeout)
     {
         _stream = stream ?? throw new ArgumentNullException(nameof(stream));
         _formatter = formatter ?? new DefaultLogFormatter(includeDate: true);

--- a/tests/Logsmith.Tests/LogManagerShutdownTests.cs
+++ b/tests/Logsmith.Tests/LogManagerShutdownTests.cs
@@ -1,0 +1,191 @@
+using System.Text;
+using Logsmith.Formatting;
+using Logsmith.Sinks;
+
+namespace Logsmith.Tests;
+
+[TestFixture]
+public class LogManagerShutdownTests
+{
+    [SetUp]
+    public void SetUp() => LogManager.Reset();
+
+    [TearDown]
+    public void TearDown() => LogManager.Reset();
+
+    [Test]
+    public async Task ShutdownAsync_DrainsBufferedEntries()
+    {
+        using var ms = new MemoryStream();
+        LogManager.Initialize(c =>
+            c.AddStreamSink(ms, leaveOpen: true, formatter: NullLogFormatter.Instance));
+
+        DispatchTestMessage(LogLevel.Information, "drain-me");
+
+        await LogManager.ShutdownAsync();
+
+        var content = Encoding.UTF8.GetString(ms.ToArray());
+        Assert.That(content, Does.Contain("drain-me"));
+    }
+
+    [Test]
+    public async Task ShutdownAsync_PostShutdownDispatch_IsNoOp()
+    {
+        var sink = new RecordingSink();
+        LogManager.Initialize(c => c.AddSink(sink));
+
+        await LogManager.ShutdownAsync();
+
+        DispatchTestMessage(LogLevel.Information, "after-shutdown");
+
+        Assert.That(sink.Entries, Has.Count.EqualTo(0));
+    }
+
+    [Test]
+    public async Task ShutdownAsync_DoubleShutdown_IsIdempotent()
+    {
+        LogManager.Initialize(c => c.AddSink(new RecordingSink()));
+
+        await LogManager.ShutdownAsync();
+
+        Assert.DoesNotThrowAsync(async () => await LogManager.ShutdownAsync());
+    }
+
+    [Test]
+    public async Task ShutdownAsync_AllowsReinitialize()
+    {
+        var sink1 = new RecordingSink();
+        LogManager.Initialize(c => c.AddSink(sink1));
+        await LogManager.ShutdownAsync();
+
+        var sink2 = new RecordingSink();
+        LogManager.Initialize(c => c.AddSink(sink2));
+
+        DispatchTestMessage(LogLevel.Information, "after-reinit");
+
+        Assert.That(sink2.Entries, Has.Count.EqualTo(1));
+        Assert.That(sink2.Entries[0].Message, Is.EqualTo("after-reinit"));
+    }
+
+    [Test]
+    public void Shutdown_Sync_DrainsBufferedEntries()
+    {
+        using var ms = new MemoryStream();
+        LogManager.Initialize(c =>
+            c.AddStreamSink(ms, leaveOpen: true, formatter: NullLogFormatter.Instance));
+
+        DispatchTestMessage(LogLevel.Information, "sync-drain");
+
+        LogManager.Shutdown();
+
+        var content = Encoding.UTF8.GetString(ms.ToArray());
+        Assert.That(content, Does.Contain("sync-drain"));
+    }
+
+    [Test]
+    public async Task ReconfigureAsync_DisposesOldSinks()
+    {
+        var disposableSink = new TrackingDisposableSink();
+        LogManager.Initialize(c => c.AddSink(disposableSink));
+
+        var newSink = new RecordingSink();
+        await LogManager.ReconfigureAsync(c => c.AddSink(newSink));
+
+        Assert.That(disposableSink.Disposed, Is.True);
+    }
+
+    [Test]
+    public async Task ReconfigureAsync_OldBufferedSink_IsDrained()
+    {
+        using var ms = new MemoryStream();
+        LogManager.Initialize(c =>
+            c.AddStreamSink(ms, leaveOpen: true, formatter: NullLogFormatter.Instance));
+
+        DispatchTestMessage(LogLevel.Information, "before-reconfig");
+
+        await LogManager.ReconfigureAsync(c => c.AddSink(new RecordingSink()));
+
+        var content = Encoding.UTF8.GetString(ms.ToArray());
+        Assert.That(content, Does.Contain("before-reconfig"));
+    }
+
+    [Test]
+    public async Task DrainTimeout_CancelsStuckDrain()
+    {
+        var sink = new HangingSink(drainTimeout: TimeSpan.FromMilliseconds(200));
+        LogManager.Initialize(c => c.AddSink(sink));
+
+        DispatchTestMessage(LogLevel.Information, "will-hang");
+
+        // ShutdownAsync should complete within a reasonable time despite the hanging sink
+        var shutdownTask = LogManager.ShutdownAsync().AsTask();
+        var completed = await Task.WhenAny(shutdownTask, Task.Delay(TimeSpan.FromSeconds(5)));
+
+        Assert.That(completed, Is.SameAs(shutdownTask), "Shutdown should not hang forever");
+    }
+
+    [Test]
+    public async Task ShutdownAsync_WithTimeout_CompletesEvenIfSinksAreSlow()
+    {
+        var sink = new HangingSink(drainTimeout: TimeSpan.FromSeconds(30));
+        LogManager.Initialize(c => c.AddSink(sink));
+
+        DispatchTestMessage(LogLevel.Information, "slow-write");
+
+        // Shutdown with a short timeout
+        var shutdownTask = LogManager.ShutdownAsync(TimeSpan.FromMilliseconds(200)).AsTask();
+        var completed = await Task.WhenAny(shutdownTask, Task.Delay(TimeSpan.FromSeconds(5)));
+
+        Assert.That(completed, Is.SameAs(shutdownTask), "Shutdown with timeout should not hang");
+    }
+
+    [Test]
+    public async Task ShutdownAsync_DisposesNonBufferedSinks()
+    {
+        var disposableSink = new TrackingDisposableSink();
+        LogManager.Initialize(c => c.AddSink(disposableSink));
+
+        await LogManager.ShutdownAsync();
+
+        Assert.That(disposableSink.Disposed, Is.True);
+    }
+
+    private static void DispatchTestMessage(LogLevel level, string message, string category = "Test")
+    {
+        if (!LogManager.IsEnabled(level, category))
+            return;
+
+        var entry = new LogEntry(
+            level: level,
+            eventId: 1,
+            timestampTicks: DateTime.UtcNow.Ticks,
+            category: category);
+
+        var utf8 = Encoding.UTF8.GetBytes(message).AsSpan();
+
+        LogManager.Dispatch(in entry, utf8, 0, static (writer, state) => { });
+    }
+
+    private sealed class TrackingDisposableSink : ILogSink
+    {
+        public bool Disposed { get; private set; }
+
+        public bool IsEnabled(LogLevel level) => true;
+
+        public void Write(in LogEntry entry, ReadOnlySpan<byte> utf8Message) { }
+
+        public void Dispose() => Disposed = true;
+    }
+
+    private sealed class HangingSink : BufferedLogSink
+    {
+        public HangingSink(TimeSpan drainTimeout)
+            : base(LogLevel.Trace, capacity: 1024, drainTimeout: drainTimeout) { }
+
+        protected override async Task WriteBufferedAsync(BufferedEntry entry, CancellationToken ct)
+        {
+            // Simulate a hung write that only responds to cancellation
+            await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
 - Closes #8
 - Adds `ShutdownAsync()`/`Shutdown()` for coordinated sink disposal with optional timeout
 - Adds `ReconfigureAsync()` that awaits old sink disposal; sync `Reconfigure()` fires-and-forgets
 - Adds configurable drain timeout to `BufferedLogSink` (default 30s) to prevent indefinite hangs
 - Auto-registers `ProcessExit` hook on `Initialize()` as a safety net (5s timeout)
 - `SinkSet` now tracks all sinks for disposal; `LogConfig.DisposeAllAsync()` disposes monitors + sinks
 - `Reset()` (test helper) now fully disposes sinks, not just monitors

## Reason for Change
`LogManager` had no public shutdown path. Buffered sinks (`FileSink`, `StreamSink`) silently lost queued entries on process exit. `Reconfigure()` disposed monitors but leaked old sinks (file handles, drain tasks). `BufferedLogSink.DisposeAsync()` awaited the drain task with no timeout, risking indefinite hangs on stuck network streams.

## Impact
- All existing `Initialize()` calls now auto-register a `ProcessExit` safety-net hook
- `Reconfigure()` now disposes old sinks (previously leaked) via fire-and-forget
- `BufferedLogSink` now defaults to 30s drain timeout (previously infinite)

## Migration Steps
- No breaking API changes — all new parameters have defaults matching safe behavior
- Callers should add `await LogManager.ShutdownAsync()` (or `LogManager.Shutdown()`) at app exit for explicit control
- Custom `BufferedLogSink` subclasses gain a `drainTimeout` constructor parameter (optional, defaults to 30s)

## Performance Considerations
- No hot-path changes — `Dispatch()` is untouched
- `ProcessExit` hook is a one-time static event registration
- Drain timeout uses `Task.WaitAsync` + `CancellationTokenSource` only during disposal

## Security Considerations
None.

## Breaking Changes
### Consumer-facing
- None — all new APIs are additive, all existing signatures preserved with default parameters

### Internal
- `SinkSet` constructor now requires an `allSinks` array parameter
- `LogConfig.Reset()` now disposes sinks (previously only disposed monitors)
- `BufferedLogSink` default drain behavior changed from infinite wait to 30s timeout