### PR TITLE
Move CaptureUnhandledExceptions into config builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Opt-in monitors for adjusting log levels at runtime without full reconfiguration
 
 ### Global Exception Handler
 
-`CaptureUnhandledExceptions` wires `AppDomain.UnhandledException` and `TaskScheduler.UnobservedTaskException` to a user-provided callback with opt-in `SetObserved()` support.
+`CaptureUnhandledExceptions` wires `AppDomain.UnhandledException` and `TaskScheduler.UnobservedTaskException` to the `InternalErrorHandler` with opt-in `SetObserved()` support. Configured via the builder, its lifecycle is tied to `Reconfigure()` and `Shutdown()`.
 
 ### Microsoft.Extensions.Logging Bridge
 
@@ -720,12 +720,14 @@ Monitors are created during `Build()` and stored in the config. When `Reconfigur
 
 ## Global Exception Handler
 
-Explicit opt-in for capturing unhandled and unobserved task exceptions.
+Explicit opt-in for capturing unhandled and unobserved task exceptions, configured via the builder.
 
 ```csharp
-LogManager.CaptureUnhandledExceptions(ex =>
+LogManager.Initialize(cfg =>
 {
-    Log.UnhandledException(ex);
+    cfg.AddConsoleSink();
+    cfg.InternalErrorHandler = ex => Console.Error.WriteLine(ex);
+    cfg.CaptureUnhandledExceptions();
 });
 ```
 
@@ -733,26 +735,23 @@ This wires:
 - `AppDomain.CurrentDomain.UnhandledException` — captures unhandled exceptions on any thread.
 - `TaskScheduler.UnobservedTaskException` — captures exceptions from unawaited tasks.
 
-The handler runs inside a `try/catch` — a failing handler cannot crash the process.
+Captured exceptions are routed to `InternalErrorHandler`. The handler runs inside a `try/catch` — a failing handler cannot crash the process.
 
 ### Observing task exceptions
 
 By default, unobserved task exceptions are logged but not observed. To also call `SetObserved()` (preventing process termination in certain configurations):
 
 ```csharp
-LogManager.CaptureUnhandledExceptions(ex =>
-{
-    Log.UnhandledException(ex);
-}, observeTaskExceptions: true);
+cfg.CaptureUnhandledExceptions(observeTaskExceptions: true);
 ```
 
-### Stopping capture
+### Lifecycle
 
-```csharp
-LogManager.StopCapturingUnhandledExceptions();
-```
+Exception capture is tied to the logging configuration lifecycle:
+- `Reconfigure()` — old config unsubscribes, new config subscribes (if configured).
+- `Shutdown()` — unsubscribes automatically.
 
-`Reset()` calls this automatically for test isolation.
+No manual `StopCapturing` call is needed.
 
 ---
 
@@ -1166,11 +1165,13 @@ The configuration object is immutable. Reconfiguration builds a new config and s
 ### Global exception handler
 
 ```csharp
-LogManager.CaptureUnhandledExceptions(
-    handler: ex => Log.UnhandledException(ex),
-    observeTaskExceptions: false);   // true to call SetObserved()
-
-LogManager.StopCapturingUnhandledExceptions();
+LogManager.Initialize(cfg =>
+{
+    cfg.InternalErrorHandler = ex => Console.Error.WriteLine(ex);
+    cfg.CaptureUnhandledExceptions(observeTaskExceptions: false); // true to call SetObserved()
+    // ...
+});
+// Automatically unsubscribed on Reconfigure() or Shutdown()
 ```
 
 ### MSBuild properties

--- a/src/Logsmith/Internal/LogConfig.cs
+++ b/src/Logsmith/Internal/LogConfig.cs
@@ -9,19 +9,25 @@ internal sealed class LogConfig
     internal readonly SinkSet Sinks;
     internal readonly Action<Exception>? ErrorHandler;
     internal readonly IDisposable[]? Monitors;
+    internal readonly bool CaptureUnhandledExceptions;
+    internal readonly bool ObserveTaskExceptions;
 
     internal LogConfig(
         LogLevel minimumLevel,
         Dictionary<string, LogLevel> categoryOverrides,
         SinkSet sinks,
         Action<Exception>? errorHandler = null,
-        IDisposable[]? monitors = null)
+        IDisposable[]? monitors = null,
+        bool captureUnhandledExceptions = false,
+        bool observeTaskExceptions = false)
     {
         MinimumLevel = minimumLevel;
         CategoryOverrides = categoryOverrides.ToFrozenDictionary();
         Sinks = sinks;
         ErrorHandler = errorHandler;
         Monitors = monitors;
+        CaptureUnhandledExceptions = captureUnhandledExceptions;
+        ObserveTaskExceptions = observeTaskExceptions;
     }
 
     internal void DisposeMonitors()

--- a/src/Logsmith/LogConfigBuilder.cs
+++ b/src/Logsmith/LogConfigBuilder.cs
@@ -9,6 +9,8 @@ public sealed class LogConfigBuilder
     private readonly List<ILogSink> _sinks = new();
     private readonly Dictionary<string, LogLevel> _categoryOverrides = new();
     private readonly List<Func<IDisposable>> _monitorFactories = new();
+    private bool _captureUnhandledExceptions;
+    private bool _observeTaskExceptions;
 
     public LogLevel MinimumLevel { get; set; } = LogLevel.Information;
     public Action<Exception>? InternalErrorHandler { get; set; }
@@ -70,6 +72,12 @@ public sealed class LogConfigBuilder
         _sinks.Clear();
     }
 
+    public void CaptureUnhandledExceptions(bool observeTaskExceptions = false)
+    {
+        _captureUnhandledExceptions = true;
+        _observeTaskExceptions = observeTaskExceptions;
+    }
+
     public void WatchEnvironmentVariable(string name = "LOGSMITH_LEVEL", TimeSpan? pollInterval = null)
     {
         var interval = pollInterval ?? TimeSpan.FromSeconds(5);
@@ -93,6 +101,7 @@ public sealed class LogConfigBuilder
             for (int i = 0; i < _monitorFactories.Count; i++)
                 monitors[i] = _monitorFactories[i]();
         }
-        return new LogConfig(MinimumLevel, _categoryOverrides, sinkSet, InternalErrorHandler, monitors);
+        return new LogConfig(MinimumLevel, _categoryOverrides, sinkSet, InternalErrorHandler, monitors,
+            _captureUnhandledExceptions, _observeTaskExceptions);
     }
 }

--- a/src/Logsmith/LogManager.cs
+++ b/src/Logsmith/LogManager.cs
@@ -6,7 +6,6 @@ public static class LogManager
 {
     private static volatile LogConfig? _config;
     private static int _initialized;
-    private static Action<Exception>? _exceptionHandler;
     private static int _exceptionsCaptured;
     private static int _processExitRegistered;
     private static int _shutdownCompleted;
@@ -22,16 +21,22 @@ public static class LogManager
         configure(builder);
         _config = builder.Build();
 
+        StartCapturingExceptions(_config);
+
         Interlocked.Exchange(ref _shutdownCompleted, 0);
         RegisterProcessExitHook();
     }
 
     public static void Reconfigure(Action<LogConfigBuilder> configure)
     {
+        StopCapturingExceptions();
+
         var old = _config;
         var builder = new LogConfigBuilder();
         configure(builder);
         _config = builder.Build();
+
+        StartCapturingExceptions(_config);
 
         if (old is not null)
             Task.Run(async () => await old.DisposeAllAsync());
@@ -39,10 +44,14 @@ public static class LogManager
 
     public static async ValueTask ReconfigureAsync(Action<LogConfigBuilder> configure)
     {
+        StopCapturingExceptions();
+
         var old = _config;
         var builder = new LogConfigBuilder();
         configure(builder);
         _config = builder.Build();
+
+        StartCapturingExceptions(_config);
 
         if (old is not null)
             await old.DisposeAllAsync();
@@ -53,7 +62,7 @@ public static class LogManager
         if (Interlocked.CompareExchange(ref _shutdownCompleted, 1, 0) != 0)
             return;
 
-        StopCapturingUnhandledExceptions();
+        StopCapturingExceptions();
 
         var old = Interlocked.Exchange(ref _config, null);
         Interlocked.Exchange(ref _initialized, 0);
@@ -202,22 +211,20 @@ public static class LogManager
         }
     }
 
-    public static void CaptureUnhandledExceptions(Action<Exception> handler, bool observeTaskExceptions = false)
+    private static void StartCapturingExceptions(LogConfig config)
     {
-        if (Interlocked.CompareExchange(ref _exceptionsCaptured, 1, 0) != 0)
-            return;
-
-        Volatile.Write(ref _exceptionHandler, handler);
+        if (!config.CaptureUnhandledExceptions) return;
+        if (Interlocked.CompareExchange(ref _exceptionsCaptured, 1, 0) != 0) return;
 
         AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
 
-        if (observeTaskExceptions)
+        if (config.ObserveTaskExceptions)
             TaskScheduler.UnobservedTaskException += OnUnobservedTaskExceptionObserve;
         else
             TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
     }
 
-    public static void StopCapturingUnhandledExceptions()
+    private static void StopCapturingExceptions()
     {
         if (Interlocked.CompareExchange(ref _exceptionsCaptured, 0, 1) != 1)
             return;
@@ -225,12 +232,11 @@ public static class LogManager
         AppDomain.CurrentDomain.UnhandledException -= OnUnhandledException;
         TaskScheduler.UnobservedTaskException -= OnUnobservedTaskException;
         TaskScheduler.UnobservedTaskException -= OnUnobservedTaskExceptionObserve;
-        Volatile.Write(ref _exceptionHandler, null);
     }
 
     private static void OnUnhandledException(object sender, UnhandledExceptionEventArgs e)
     {
-        var handler = Volatile.Read(ref _exceptionHandler);
+        var handler = _config?.ErrorHandler;
         if (handler is null) return;
 
         if (e.ExceptionObject is Exception ex)
@@ -241,7 +247,7 @@ public static class LogManager
 
     private static void OnUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
     {
-        var handler = Volatile.Read(ref _exceptionHandler);
+        var handler = _config?.ErrorHandler;
         if (handler is null) return;
 
         try { handler(e.Exception); } catch { }
@@ -249,7 +255,7 @@ public static class LogManager
 
     private static void OnUnobservedTaskExceptionObserve(object? sender, UnobservedTaskExceptionEventArgs e)
     {
-        var handler = Volatile.Read(ref _exceptionHandler);
+        var handler = _config?.ErrorHandler;
         if (handler is null) return;
 
         try { handler(e.Exception); } catch { }
@@ -274,7 +280,8 @@ public static class LogManager
         var current = _config;
         if (current is null) return;
 
-        var newConfig = new LogConfig(level, current.CategoryOverrides.ToDictionary(), current.Sinks, current.ErrorHandler, current.Monitors);
+        var newConfig = new LogConfig(level, current.CategoryOverrides.ToDictionary(), current.Sinks, current.ErrorHandler, current.Monitors,
+            current.CaptureUnhandledExceptions, current.ObserveTaskExceptions);
         _config = newConfig;
     }
 
@@ -283,14 +290,15 @@ public static class LogManager
         var current = _config;
         if (current is null) return;
 
-        var newConfig = new LogConfig(current.MinimumLevel, overrides, current.Sinks, current.ErrorHandler, current.Monitors);
+        var newConfig = new LogConfig(current.MinimumLevel, overrides, current.Sinks, current.ErrorHandler, current.Monitors,
+            current.CaptureUnhandledExceptions, current.ObserveTaskExceptions);
         _config = newConfig;
     }
 
     // For testing: reset state so Initialize can be called again.
     internal static void Reset()
     {
-        StopCapturingUnhandledExceptions();
+        StopCapturingExceptions();
         var old = _config;
         _config = null;
         Interlocked.Exchange(ref _initialized, 0);

--- a/tests/Logsmith.Tests/ExceptionHandlerTests.cs
+++ b/tests/Logsmith.Tests/ExceptionHandlerTests.cs
@@ -10,70 +10,130 @@ public class ExceptionHandlerTests
     public void TearDown() => LogManager.Reset();
 
     [Test]
-    public void CaptureUnhandledExceptions_SubscribesHandler()
+    public void CaptureUnhandledExceptions_ViaBuilder_SubscribesHandler()
     {
-        Exception? caught = null;
-        LogManager.CaptureUnhandledExceptions(ex => caught = ex);
+        LogManager.Initialize(cfg =>
+        {
+            cfg.AddSink(new Sinks.RecordingSink());
+            cfg.InternalErrorHandler = _ => { };
+            cfg.CaptureUnhandledExceptions();
+        });
 
-        // We can't easily trigger AppDomain.UnhandledException in tests,
-        // but we can verify the method doesn't throw and can be called.
-        Assert.Pass("Handler registered without error");
+        Assert.Pass("Handler registered via builder without error");
     }
 
     [Test]
-    public void StopCapturing_UnsubscribesCleanly()
+    public void CaptureUnhandledExceptions_WithObserveTaskExceptions()
     {
-        LogManager.CaptureUnhandledExceptions(_ => { });
-        LogManager.StopCapturingUnhandledExceptions();
-
-        // Should be able to re-register
-        LogManager.CaptureUnhandledExceptions(_ => { });
-        Assert.Pass("Re-registration succeeded");
-    }
-
-    [Test]
-    public void CaptureUnhandledExceptions_CalledTwice_IgnoresSecond()
-    {
-        int count = 0;
-        LogManager.CaptureUnhandledExceptions(_ => count++);
-        LogManager.CaptureUnhandledExceptions(_ => count += 10);
-
-        // Second call is no-op since already capturing
-        Assert.Pass("Double registration did not throw");
-    }
-
-    [Test]
-    public void UnobservedTaskException_WithObserve_CapturesException()
-    {
-        Exception? caught = null;
-        LogManager.Initialize(c => c.AddSink(new Sinks.RecordingSink()));
-        LogManager.CaptureUnhandledExceptions(ex => caught = ex, observeTaskExceptions: true);
+        LogManager.Initialize(cfg =>
+        {
+            cfg.AddSink(new Sinks.RecordingSink());
+            cfg.InternalErrorHandler = _ => { };
+            cfg.CaptureUnhandledExceptions(observeTaskExceptions: true);
+        });
 
         // Create a faulted task and let it be collected
         var weakRef = CreateFaultedTask();
 
-        // Force GC to trigger UnobservedTaskException
         GC.Collect();
         GC.WaitForPendingFinalizers();
         GC.Collect();
 
-        // Give time for the event to fire
         Thread.Sleep(200);
 
-        // Note: UnobservedTaskException only fires during finalization,
-        // which is non-deterministic. We just verify no crash.
-        Assert.Pass("No crash from unobserved task exception handling");
+        Assert.Pass("No crash from unobserved task exception handling with observe");
+    }
+
+    [Test]
+    public void Shutdown_UnsubscribesAutomatically()
+    {
+        LogManager.Initialize(cfg =>
+        {
+            cfg.AddSink(new Sinks.RecordingSink());
+            cfg.InternalErrorHandler = _ => { };
+            cfg.CaptureUnhandledExceptions();
+        });
+
+        LogManager.Shutdown();
+
+        // After shutdown we can re-initialize with capture
+        LogManager.Initialize(cfg =>
+        {
+            cfg.AddSink(new Sinks.RecordingSink());
+            cfg.CaptureUnhandledExceptions();
+        });
+
+        Assert.Pass("Re-initialization with capture succeeded after shutdown");
+    }
+
+    [Test]
+    public void Reconfigure_WithoutCapture_UnsubscribesOldHandlers()
+    {
+        LogManager.Initialize(cfg =>
+        {
+            cfg.AddSink(new Sinks.RecordingSink());
+            cfg.InternalErrorHandler = _ => { };
+            cfg.CaptureUnhandledExceptions();
+        });
+
+        // Reconfigure without capture — old handlers should be unsubscribed
+        LogManager.Reconfigure(cfg =>
+        {
+            cfg.AddSink(new Sinks.RecordingSink());
+        });
+
+        Assert.Pass("Reconfigure without capture did not throw");
+    }
+
+    [Test]
+    public void Reconfigure_WithCapture_ResubscribesHandlers()
+    {
+        LogManager.Initialize(cfg =>
+        {
+            cfg.AddSink(new Sinks.RecordingSink());
+            cfg.CaptureUnhandledExceptions();
+        });
+
+        // Reconfigure with capture — should unsub old, sub new
+        LogManager.Reconfigure(cfg =>
+        {
+            cfg.AddSink(new Sinks.RecordingSink());
+            cfg.CaptureUnhandledExceptions(observeTaskExceptions: true);
+        });
+
+        Assert.Pass("Reconfigure with capture re-subscription succeeded");
     }
 
     [Test]
     public void Reset_StopsCapturing()
     {
-        LogManager.CaptureUnhandledExceptions(_ => { });
+        LogManager.Initialize(cfg =>
+        {
+            cfg.AddSink(new Sinks.RecordingSink());
+            cfg.CaptureUnhandledExceptions();
+        });
+
         LogManager.Reset();
 
-        // After reset, should be able to capture again
-        LogManager.CaptureUnhandledExceptions(_ => { });
+        // After reset, should be able to initialize with capture again
+        LogManager.Initialize(cfg =>
+        {
+            cfg.AddSink(new Sinks.RecordingSink());
+            cfg.CaptureUnhandledExceptions();
+        });
+
         Assert.Pass("Reset cleared exception handler state");
+    }
+
+    [Test]
+    public void Initialize_WithoutCapture_DoesNotSubscribe()
+    {
+        LogManager.Initialize(cfg =>
+        {
+            cfg.AddSink(new Sinks.RecordingSink());
+        });
+
+        Assert.Pass("Initialize without capture succeeded");
     }
 
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]


### PR DESCRIPTION
## Summary
- Closes #10

## Reason for Change
`CaptureUnhandledExceptions` was a standalone static method on `LogManager` with a lifetime decoupled from the logging configuration. Developers had to manually call `StopCapturingUnhandledExceptions()`, and forgetting to do so leaked event subscriptions. Moving it into the config builder ties its lifecycle to `Reconfigure()` and `Shutdown()`.

## Impact
- `LogConfigBuilder` gains `CaptureUnhandledExceptions(bool observeTaskExceptions = false)` method
- `LogConfig` stores capture flags; handlers are automatically subscribed/unsubscribed during config swaps
- Event handlers now read from `_config?.ErrorHandler` (the `InternalErrorHandler`) instead of a separate static delegate
- `SetMinimumLevel`/`SetCategoryOverrides` internal methods carry exception capture flags to new configs

## Migration Steps
Replace:
```csharp
LogManager.CaptureUnhandledExceptions(ex => Log.Error(ex), observeTaskExceptions: true);
// ... later ...
LogManager.StopCapturingUnhandledExceptions();
```
With:
```csharp
LogManager.Initialize(cfg =>
{
    cfg.InternalErrorHandler = ex => Console.Error.WriteLine(ex);
    cfg.CaptureUnhandledExceptions(observeTaskExceptions: true);
    // ...
});
// Automatically unsubscribed on Reconfigure() or Shutdown()
```

## Performance Considerations
No performance impact — same `Interlocked` guard pattern, same event handler logic.

## Security Considerations
None.

## Breaking Changes
- **Consumer-facing**: `LogManager.CaptureUnhandledExceptions()` and `LogManager.StopCapturingUnhandledExceptions()` public methods removed. Exception handler parameter removed — routes to `InternalErrorHandler` instead.
- **Internal**: `_exceptionHandler` static field removed from `LogManager`.