### PR TITLE
Add BufferedLogSink drop visibility (counter + error handler)

### DIFF
--- a/src/Logsmith/LogConfigBuilder.cs
+++ b/src/Logsmith/LogConfigBuilder.cs
@@ -52,7 +52,7 @@ public sealed class LogConfigBuilder
     {
         AddSink(new Sinks.FileSink(path, formatter: formatter, shared: shared,
             rollingInterval: rollingInterval, maxFileSizeBytes: maxFileSizeBytes,
-            drainTimeout: drainTimeout));
+            drainTimeout: drainTimeout, errorHandler: InternalErrorHandler));
     }
 
     public void AddDebugSink(ILogFormatter? formatter = null)
@@ -64,7 +64,7 @@ public sealed class LogConfigBuilder
                               TimeSpan? drainTimeout = null)
     {
         AddSink(new Sinks.StreamSink(stream, formatter: formatter, leaveOpen: leaveOpen,
-            drainTimeout: drainTimeout));
+            drainTimeout: drainTimeout, errorHandler: InternalErrorHandler));
     }
 
     public void ClearSinks()

--- a/src/Logsmith/LogDroppedException.cs
+++ b/src/Logsmith/LogDroppedException.cs
@@ -1,0 +1,14 @@
+namespace Logsmith;
+
+/// <summary>
+/// Raised via the internal error handler when a <see cref="Sinks.BufferedLogSink"/>
+/// drops a log message because its bounded channel is full.
+/// </summary>
+public sealed class LogDroppedException : Exception
+{
+    public long TotalDropped { get; }
+
+    public LogDroppedException(long totalDropped)
+        : base($"Log message dropped. Total dropped: {totalDropped}")
+        => TotalDropped = totalDropped;
+}

--- a/src/Logsmith/Sinks/BufferedLogSink.cs
+++ b/src/Logsmith/Sinks/BufferedLogSink.cs
@@ -23,12 +23,22 @@ public abstract class BufferedLogSink : ILogSink, IFlushableLogSink, IAsyncDispo
     private readonly Task _drainTask;
     private readonly CancellationTokenSource _cts = new();
     private readonly TimeSpan _drainTimeout;
+    private readonly Action<Exception>? _errorHandler;
+
+    private long _droppedCount;
+    private long _lastDropNotifyTicks;
+
+    /// <summary>
+    /// Total number of log messages dropped because the bounded channel was full.
+    /// </summary>
+    public long DroppedCount => Volatile.Read(ref _droppedCount);
 
     protected BufferedLogSink(LogLevel minimumLevel = LogLevel.Trace, int capacity = 1024,
-                              TimeSpan? drainTimeout = null)
+                              TimeSpan? drainTimeout = null, Action<Exception>? errorHandler = null)
     {
         MinimumLevel = minimumLevel;
         _drainTimeout = drainTimeout ?? TimeSpan.FromSeconds(30);
+        _errorHandler = errorHandler;
         _channel = Channel.CreateBounded<BufferedEntry>(new BoundedChannelOptions(capacity)
         {
             FullMode = BoundedChannelFullMode.Wait,
@@ -47,7 +57,21 @@ public abstract class BufferedLogSink : ILogSink, IFlushableLogSink, IAsyncDispo
         var buffered = new BufferedEntry(entry, rented, utf8Message.Length);
 
         if (!_channel.Writer.TryWrite(buffered))
+        {
             ArrayPool<byte>.Shared.Return(rented);
+            var count = Interlocked.Increment(ref _droppedCount);
+
+            // Notify on first drop, then at most once per second
+            var now = Environment.TickCount64;
+            var lastNotify = Volatile.Read(ref _lastDropNotifyTicks);
+            if (count == 1 || now - lastNotify >= 1000)
+            {
+                if (Interlocked.CompareExchange(ref _lastDropNotifyTicks, now, lastNotify) == lastNotify)
+                {
+                    _errorHandler?.Invoke(new LogDroppedException(count));
+                }
+            }
+        }
     }
 
     protected abstract Task WriteBufferedAsync(BufferedEntry entry, CancellationToken ct);

--- a/src/Logsmith/Sinks/FileSink.cs
+++ b/src/Logsmith/Sinks/FileSink.cs
@@ -21,8 +21,8 @@ public class FileSink : BufferedLogSink
                     long maxFileSizeBytes = 10 * 1024 * 1024,
                     ILogFormatter? formatter = null, bool shared = false,
                     RollingInterval rollingInterval = RollingInterval.None,
-                    TimeSpan? drainTimeout = null)
-        : base(minimumLevel, drainTimeout: drainTimeout)
+                    TimeSpan? drainTimeout = null, Action<Exception>? errorHandler = null)
+        : base(minimumLevel, drainTimeout: drainTimeout, errorHandler: errorHandler)
     {
         _basePath = Path.GetFullPath(path);
         _maxFileSizeBytes = maxFileSizeBytes;

--- a/src/Logsmith/Sinks/StreamSink.cs
+++ b/src/Logsmith/Sinks/StreamSink.cs
@@ -12,8 +12,8 @@ public class StreamSink : BufferedLogSink
 
     public StreamSink(Stream stream, LogLevel minimumLevel = LogLevel.Trace,
                       ILogFormatter? formatter = null, bool leaveOpen = false, int capacity = 1024,
-                      TimeSpan? drainTimeout = null)
-        : base(minimumLevel, capacity, drainTimeout: drainTimeout)
+                      TimeSpan? drainTimeout = null, Action<Exception>? errorHandler = null)
+        : base(minimumLevel, capacity, drainTimeout: drainTimeout, errorHandler: errorHandler)
     {
         _stream = stream ?? throw new ArgumentNullException(nameof(stream));
         _formatter = formatter ?? new DefaultLogFormatter(includeDate: true);

--- a/tests/Logsmith.Tests/SinkTests/BufferedLogSinkTests.cs
+++ b/tests/Logsmith.Tests/SinkTests/BufferedLogSinkTests.cs
@@ -101,6 +101,101 @@ public class BufferedLogSinkTests
         sink.Dispose();
     }
 
+    [Test]
+    public void Write_ChannelFull_IncrementsDroppedCount()
+    {
+        using var ms = new MemoryStream();
+        var sink = new SlowStreamSink(ms, capacity: 1);
+        var entry = MakeEntry();
+
+        // Fill the channel and force drops
+        for (int i = 0; i < 50; i++)
+            sink.Write(in entry, "drop-test"u8);
+
+        Assert.That(sink.DroppedCount, Is.GreaterThan(0));
+        sink.Dispose();
+    }
+
+    [Test]
+    public void Write_ChannelFull_ErrorHandlerCalledWithLogDroppedException()
+    {
+        var exceptions = new List<Exception>();
+        using var ms = new MemoryStream();
+        var sink = new SlowStreamSink(ms, capacity: 1, errorHandler: ex => exceptions.Add(ex));
+        var entry = MakeEntry();
+
+        for (int i = 0; i < 50; i++)
+            sink.Write(in entry, "handler-test"u8);
+
+        Assert.That(exceptions, Is.Not.Empty);
+        Assert.That(exceptions[0], Is.TypeOf<LogDroppedException>());
+        Assert.That(((LogDroppedException)exceptions[0]).TotalDropped, Is.GreaterThanOrEqualTo(1));
+        sink.Dispose();
+    }
+
+    [Test]
+    public void Write_ChannelFull_ErrorHandlerIsThrottled()
+    {
+        var callCount = 0;
+        using var ms = new MemoryStream();
+        var sink = new SlowStreamSink(ms, capacity: 1, errorHandler: _ => Interlocked.Increment(ref callCount));
+        var entry = MakeEntry();
+
+        // Rapid-fire drops all happen within the same tick window
+        for (int i = 0; i < 200; i++)
+            sink.Write(in entry, "throttle"u8);
+
+        // Throttle should limit notifications — far fewer callbacks than drops
+        Assert.That(callCount, Is.LessThan(sink.DroppedCount));
+        sink.Dispose();
+    }
+
+    [Test]
+    public void Write_ChannelFull_ConcurrentDropCountIsAccurate()
+    {
+        using var ms = new MemoryStream();
+        var sink = new SlowStreamSink(ms, capacity: 1);
+        var entry = MakeEntry();
+        var barrier = new Barrier(4);
+
+        var tasks = Enumerable.Range(0, 4).Select(_ => Task.Run(() =>
+        {
+            barrier.SignalAndWait();
+            for (int i = 0; i < 100; i++)
+                sink.Write(in entry, "concurrent"u8);
+        })).ToArray();
+
+        Task.WaitAll(tasks);
+
+        // DroppedCount should be consistent (>0 since capacity=1 with slow consumer and 4 threads)
+        Assert.That(sink.DroppedCount, Is.GreaterThan(0));
+        sink.Dispose();
+    }
+
+    [Test]
+    public async Task Write_ChannelNotFull_NoDropsReported()
+    {
+        using var ms = new MemoryStream();
+        var errorCalled = false;
+        var sink = new StreamSink(ms, formatter: NullLogFormatter.Instance, leaveOpen: true,
+            capacity: 1024, errorHandler: _ => errorCalled = true);
+        var entry = MakeEntry();
+
+        sink.Write(in entry, "no-drop"u8);
+        await sink.DisposeAsync();
+
+        Assert.That(sink.DroppedCount, Is.EqualTo(0));
+        Assert.That(errorCalled, Is.False);
+    }
+
+    [Test]
+    public void LogDroppedException_TotalDropped_ReflectsCount()
+    {
+        var ex = new LogDroppedException(42);
+        Assert.That(ex.TotalDropped, Is.EqualTo(42));
+        Assert.That(ex.Message, Does.Contain("42"));
+    }
+
     private static LogEntry MakeEntry() => new(
         LogLevel.Information, 1, DateTime.UtcNow.Ticks, "Test");
 
@@ -111,8 +206,9 @@ public class BufferedLogSinkTests
     {
         private readonly Stream _stream;
 
-        public SlowStreamSink(Stream stream, int capacity = 1)
-            : base(LogLevel.Trace, capacity)
+        public SlowStreamSink(Stream stream, int capacity = 1,
+                              Action<Exception>? errorHandler = null)
+            : base(LogLevel.Trace, capacity, errorHandler: errorHandler)
         {
             _stream = stream;
         }


### PR DESCRIPTION
## Summary
 - Closes #11
 - Adds atomic `DroppedCount` property to `BufferedLogSink` for monitoring dropped messages
 - Routes drop events through `InternalErrorHandler` with per-second throttling via `LogDroppedException`
 - Threads `errorHandler` through `FileSink`, `StreamSink`, and `LogConfigBuilder` helper methods

## Reason for Change
When `BufferedLogSink`'s bounded channel is full, `TryWrite()` fails and messages are silently dropped. Applications have no way to detect log data loss under back-pressure.

## Impact
- `BufferedLogSink` now exposes a `DroppedCount` property queryable for health checks and metrics
- If `InternalErrorHandler` is configured, it receives `LogDroppedException` on the first drop and then at most once per second
- All existing behavior is preserved — no changes to normal (non-drop) code paths

## Migration Steps
No migration required. The new `errorHandler` parameter on `BufferedLogSink`, `FileSink`, and `StreamSink` constructors is optional with a default of `null`. Existing code compiles and behaves identically.

## Performance Considerations
- Drop path adds one `Interlocked.Increment` and one `Volatile.Read` — negligible overhead
- Throttle CAS prevents cascading error handler calls under sustained load
- Normal (non-drop) write path is unchanged

## Security Considerations
None.

## Breaking Changes
  - Consumer-facing: None
  - Internal: None